### PR TITLE
Calling bottle :unneeded is deprecated

### DIFF
--- a/railway.rb
+++ b/railway.rb
@@ -6,7 +6,6 @@ class Railway < Formula
   desc "Develop and deploy code with zero configuration"
   homepage "https://railway.app"
   version "0.2.45"
-  bottle :unneeded
 
   on_macos do
     if Hardware::CPU.intel?


### PR DESCRIPTION
brew warning:
```sh
Warning: Calling bottle :unneeded is deprecated! There is no replacement.
Please report this issue to the railwayapp/railway tap (not Homebrew/brew or Homebrew/core):
  /opt/homebrew/Library/Taps/railwayapp/homebrew-railway/railway.rb:9
```